### PR TITLE
test: set git user name and email in repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 default_stages: [commit]
 exclude: ^tests/data/
 repos:
@@ -8,7 +9,7 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0 # Use the ref you want to point at
+    rev: v3.3.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -26,7 +27,8 @@ repos:
     rev: v0.25.0
     hooks:
       - id: markdownlint
-        exclude: ^(docs/arch/adr-template\.md|\.github/ISSUE_TEMPLATE/)
+        exclude: >-
+          ^(docs/arch/adr-template\.md|\.github/ISSUE_TEMPLATE/|\.stentor\.d/)
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.25.0
     hooks:

--- a/.stentor.d/1.fix.git-test-failures.md
+++ b/.stentor.d/1.fix.git-test-failures.md
@@ -1,0 +1,2 @@
+When creating repositories during tests, configure the user name and email
+to avoid failures in CI.

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
+	"sassoftware.io/clis/gotagger/internal/testutils"
 )
 
 // tests that inject a mock runner function
@@ -114,6 +115,9 @@ func makeGitRepo(t *testing.T) string {
 	}
 	// init git repo
 	runTestGitCommand(t, path, "init")
+	// confiure user name and email
+	runTestGitCommand(t, path, "config", "user.email", testutils.GotaggerEmail)
+	runTestGitCommand(t, path, "config", "user.name", testutils.GotaggerName)
 	// commit a file
 	commitFile(t, path, "foo", "Commit foo", []byte("foo"))
 	// commit a change to the file

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -21,6 +22,7 @@ const (
 
 type T interface {
 	Errorf(string, ...interface{})
+	FailNow()
 	Fatal(...interface{})
 	Fatalf(string, ...interface{})
 	Helper()
@@ -104,9 +106,15 @@ func NewGitRepo(t T) (repo *git.Repository, path string, teardown func()) {
 	// init git repo
 	var err error
 	repo, err = git.PlainInit(path, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
+	cfg, err := repo.Config()
+	require.NoError(t, err)
+
+	cfg.User.Email = GotaggerEmail
+	cfg.User.Name = GotaggerName
+
+	require.NoError(t, repo.SetConfig(cfg))
 
 	return
 }


### PR DESCRIPTION
This ensures that our tests that manipulate git repositories work even
when the global git config is not setup.

Closes #1