### PR TITLE
fix: root module wrong on windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,4 +38,4 @@ jobs:
         run: make build
 
       - name: Test
-        run: make test
+        run: make TIMEOUT=5m TESTFORMAT=testname test

--- a/.stentor.d/3.fix.windows-module-paths.md
+++ b/.stentor.d/3.fix.windows-module-paths.md
@@ -1,0 +1,3 @@
+The way gotagger was determining the path of a module relative to the
+root of the repository did not work correctly for Windows paths. This
+fixes the problem by using the `filepath.Rel` call instead.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ LINTFLAGS   =
 REPORTFLAGS = --jsonfile $(REPORTJSON) --junitfile $(REPORTXML)
 REPORTJSON  = $(REPORTDIR)/go-test.json
 REPORTXML   = $(REPORTDIR)/go-test.xml
-TESTFLAGS   = -- -timeout $(TIMEOUT) $(COVERFLAGS)
+TESTFLAGS   = --format=$(TESTFORMAT) -- -timeout $(TIMEOUT) $(COVERFLAGS)
+TESTFORMAT  = short
 TIMEOUT     = 60s
 
 # conditional flags

--- a/gotagger.go
+++ b/gotagger.go
@@ -266,9 +266,10 @@ func (g *Gotagger) findAllModules(include []string) (modules []module, err error
 		}
 
 		// add the directory leading up to any valid go.mod
-		relPath := strings.TrimPrefix(pth, g.repo.Path)
-		relPath = strings.TrimPrefix(relPath, filepathSep)
-
+		relPath, err := filepath.Rel(g.repo.Path, pth)
+		if err != nil {
+			return err
+		}
 		if strings.HasSuffix(relPath, filepathSep+goMod) || relPath == goMod {
 			data, err := ioutil.ReadFile(pth)
 			if err != nil {

--- a/gotagger_windows_test.go
+++ b/gotagger_windows_test.go
@@ -1,0 +1,33 @@
+package gotagger
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sassoftware.io/clis/gotagger/internal/git"
+	"sassoftware.io/clis/gotagger/internal/testutils"
+)
+
+func TestWindowsPaths(t *testing.T) {
+	repo, path, teardown := testutils.NewGitRepo(t)
+	defer teardown()
+
+	// ensure / in path
+	path = filepath.ToSlash(path)
+
+	simpleGoRepo(t, repo, path)
+
+	r, err := git.New(path)
+	require.NoError(t, err)
+
+	g := &Gotagger{
+		Config: NewDefaultConfig(),
+		repo:   r,
+	}
+
+	if versions, err := g.TagRepo(); assert.NoError(t, err) {
+		assert.Equal(t, []string{"v1.1.0"}, versions)
+	}
+}


### PR DESCRIPTION
The way gotagger was determining the path of a module relative to the
root of the repository did not work correctly for Windows paths. This
fixes the problem by using the `filepath.Rel` call instead.