### PR TITLE
fix: change module name

### DIFF
--- a/.stentor.d/7.fix.module-name.md
+++ b/.stentor.d/7.fix.module-name.md
@@ -1,0 +1,3 @@
+Change the module name to `github.com/sassoftware/gotagger`.
+
+We need to use this module uname until the sassoftware.io URL is ready.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ so you can ensure you build a supported release:
 mkdir tmp
 cd tmp
 go mod init fake
-go get sassoftware.io/clis/gotagger
+go get github.com/sassoftware/gotagger
 ```
 
 
@@ -157,7 +157,7 @@ in the order they are specified in the `Modules` footer.
 ## Using gotagger as a library
 
 ```go
-import sassoftware.io/clis/gotagger
+import github.com/sassoftware/gotagger
 ```
 
 Create a Gotagger instance

--- a/cmd/gotagger/main.go
+++ b/cmd/gotagger/main.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"sassoftware.io/clis/gotagger"
+	"github.com/sassoftware/gotagger"
 )
 
 const (

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
-	"sassoftware.io/clis/gotagger/internal/testutils"
+	"github.com/sassoftware/gotagger/internal/testutils"
 )
 
 // tests that inject a mock runner function

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sassoftware.io/clis/gotagger
+module github.com/sassoftware/gotagger
 
 go 1.14
 

--- a/gotagger.go
+++ b/gotagger.go
@@ -15,11 +15,11 @@ import (
 	"unicode"
 
 	"github.com/Masterminds/semver/v3"
+	ggit "github.com/sassoftware/gotagger/git"
+	"github.com/sassoftware/gotagger/internal/commit"
+	igit "github.com/sassoftware/gotagger/internal/git"
+	"github.com/sassoftware/gotagger/marker"
 	"golang.org/x/mod/modfile"
-	ggit "sassoftware.io/clis/gotagger/git"
-	"sassoftware.io/clis/gotagger/internal/commit"
-	igit "sassoftware.io/clis/gotagger/internal/git"
-	"sassoftware.io/clis/gotagger/marker"
 )
 
 const (

--- a/gotagger_test.go
+++ b/gotagger_test.go
@@ -13,10 +13,10 @@ import (
 	sgit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/sassoftware/gotagger/internal/git"
+	"github.com/sassoftware/gotagger/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sassoftware.io/clis/gotagger/internal/git"
-	"sassoftware.io/clis/gotagger/internal/testutils"
 )
 
 type setupRepoFunc func(testutils.T, *sgit.Repository, string)

--- a/gotagger_windows_test.go
+++ b/gotagger_windows_test.go
@@ -4,10 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sassoftware/gotagger/internal/git"
+	"github.com/sassoftware/gotagger/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sassoftware.io/clis/gotagger/internal/git"
-	"sassoftware.io/clis/gotagger/internal/testutils"
 )
 
 func TestWindowsPaths(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"sassoftware.io/clis/gotagger/internal/commit"
+	"github.com/sassoftware/gotagger/internal/commit"
 )
 
 var (

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sassoftware/gotagger/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sassoftware.io/clis/gotagger/internal/testutils"
 )
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
The sassoftware.io URLs isn't ready yet, so we'll use the github.com
module until it is, at which point we'll cut over to v1.0.0.