### PR TITLE
feat: add option to force tag creation

### DIFF
--- a/.stentor.d/11.feature.force-option.md
+++ b/.stentor.d/11.feature.force-option.md
@@ -1,0 +1,2 @@
+Added a `Force` option to `gotagger.Config` and a corresponding `-force` flag to the CLI.
+Setting this to `true` forces the creation of a tag, even if the HEAD is not a "release" commit.

--- a/cmd/gotagger/main.go
+++ b/cmd/gotagger/main.go
@@ -54,14 +54,15 @@ type GoTagger struct {
 	err *log.Logger
 
 	// command-line options
+	configFile     string
+	dirtyIncrement string
+	force          bool
 	modules        bool
 	pushTag        bool
 	remoteName     string
 	showVersion    bool
 	tagRelease     bool
 	versionPrefix  string
-	dirtyIncrement string
-	configFile     string
 }
 
 // Runs GoTagger.
@@ -73,6 +74,7 @@ func (g *GoTagger) Run() int {
 	flags := flag.NewFlagSet(AppName, flag.ContinueOnError)
 	flags.SetOutput(g.Stderr)
 
+	flags.BoolVar(&g.force, "force", g.boolEnv("force", false), "force creation of a tag")
 	flags.BoolVar(&g.modules, "modules", g.boolEnv("modules", true), "enable go module versioning")
 	flags.BoolVar(&g.pushTag, "push", g.boolEnv("push", false), "push the just created tag, implies -release")
 	flags.StringVar(&g.remoteName, "remote", g.stringEnv("remote", "origin"), "name of the remote to push tags to")
@@ -167,7 +169,8 @@ func (g *GoTagger) Run() int {
 		}
 	}
 
-	r.Config.CreateTag = g.tagRelease || g.pushTag
+	r.Config.Force = g.force
+	r.Config.CreateTag = g.tagRelease || g.pushTag || g.force
 	r.Config.IgnoreModules = !g.modules
 	r.Config.PushTag = g.pushTag
 	r.Config.RemoteName = g.remoteName

--- a/cmd/gotagger/main_test.go
+++ b/cmd/gotagger/main_test.go
@@ -170,6 +170,12 @@ func TestGoTagger(t *testing.T) {
 				require.NoError(t, ioutil.WriteFile(filepath.Join(path, "foo"), []byte("foo\n"), 0600))
 			},
 		},
+		{
+			title:     "force flag",
+			args:      []string{"-force"},
+			wantOut:   "v1.1.0\n",
+			extraTest: assertTag("v1.1.0"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/gotagger.go
+++ b/gotagger.go
@@ -75,6 +75,9 @@ type Config struct {
 	// CommitTypeTable used for looking up version increments based on the commit type.
 	CommitTypeTable mapper.Table
 
+	// Force controlls whether gotagger will create a tag even if HEAD is not a "release" commit.
+	Force bool
+
 	/* TODO
 	// PreRelease is the string that will be used to generate pre-release versions. The
 	// string may be a Golang text template. Valid arguments are:
@@ -216,7 +219,7 @@ func (g *Gotagger) TagRepo() ([]string, error) {
 	}
 
 	// determine if we should create and push a tag or not
-	if c.Type == mapper.TypeRelease && g.Config.CreateTag {
+	if (g.Config.Force || c.Type == mapper.TypeRelease) && g.Config.CreateTag {
 		// create tag
 		tags := make([]string, 0, len(versions))
 		for _, ver := range versions {

--- a/gotagger_test.go
+++ b/gotagger_test.go
@@ -993,6 +993,43 @@ func TestGotagger_TagRepo_ignore_modules(t *testing.T) {
 	}
 }
 
+func TestGotagger_TagRepo_force(t *testing.T) {
+	t.Parallel()
+
+	t.Run("force-false", func(t *testing.T) {
+		t.Parallel()
+		g, repo, path, teardown := newGotagger(t)
+		defer teardown()
+
+		simpleGoRepo(t, repo, path)
+
+		// gotagger should not create a tag, because HEAD is not a "release" commit
+		g.Config.CreateTag = true
+		if versions, err := g.TagRepo(); assert.NoError(t, err) {
+			assert.Equal(t, []string{"v1.1.0"}, versions)
+			_, gerr := repo.Tag("v1.1.0")
+			assert.Error(t, gerr)
+		}
+	})
+
+	t.Run("force-true", func(t *testing.T) {
+		t.Parallel()
+		g, repo, path, teardown := newGotagger(t)
+		defer teardown()
+
+		simpleGoRepo(t, repo, path)
+
+		// gotagger should create a tag, even though HEAD is not a "release" commit
+		g.Config.CreateTag = true
+		g.Config.Force = true
+		if versions, err := g.TagRepo(); assert.NoError(t, err) {
+			assert.Equal(t, []string{"v1.1.0"}, versions)
+			_, gerr := repo.Tag("v1.1.0")
+			assert.NoError(t, gerr)
+		}
+	})
+}
+
 func TestGotagger_TagRepo_validation_extra(t *testing.T) {
 	g, repo, path, teardown := newGotagger(t)
 	defer teardown()


### PR DESCRIPTION
Sometimes you don't want or need release commits. This adds an option
to `gotagger.Config` to force the creation of tags, and a CLI flag to
set the option to true.