### PR TITLE
Add option for handling dirty worktrees

### DIFF
--- a/.stentor.d/24.feat.add-dirty-option.md
+++ b/.stentor.d/24.feat.add-dirty-option.md
@@ -1,0 +1,5 @@
+Add a way to change how `gotagger` increments the version
+when there are no new commits,
+but the worktree is dirty.
+For the CLI, use the `-dirty` option.
+Go API users, set `Config.DirtyWorktreeIncrement`.

--- a/cmd/gotagger/main_test.go
+++ b/cmd/gotagger/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/sassoftware/gotagger/internal/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionInfo(t *testing.T) {
@@ -143,6 +145,30 @@ func TestGoTagger(t *testing.T) {
 			args:    []string{"-memprofile=foo/mem.prof"},
 			wantErr: "error: could not create memory profile: open ",
 			wantRc:  1,
+		},
+		{
+			title:   "invalid dirty option",
+			args:    []string{"-dirty=foo"},
+			wantErr: "error: unsupported value for -dirty: foo",
+			wantRc:  1,
+		},
+		{
+			title:   "dirty minor",
+			args:    []string{"-dirty=minor"},
+			wantOut: "v1.4.0\n",
+			extraSetup: func(t *testing.T, repo *git.Repository, path string) {
+				testutils.CreateTag(t, repo, path, "v1.3.0")
+				require.NoError(t, ioutil.WriteFile(filepath.Join(path, "foo"), []byte("foo\n"), 0600))
+			},
+		},
+		{
+			title:   "dirty patch",
+			args:    []string{"-dirty=patch"},
+			wantOut: "v1.3.1\n",
+			extraSetup: func(t *testing.T, repo *git.Repository, path string) {
+				testutils.CreateTag(t, repo, path, "v1.3.0")
+				require.NoError(t, ioutil.WriteFile(filepath.Join(path, "foo"), []byte("foo\n"), 0600))
+			},
 		},
 	}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -116,6 +116,12 @@ func (r *Repository) Head() (Commit, error) {
 	return commits[0], nil
 }
 
+// IsDirty returns a boolean indicating whether there are uncommited changes.
+func (r *Repository) IsDirty() (bool, error) {
+	out, err := r.run([]string{"status", "--porcelain"})
+	return out != "", err
+}
+
 // PushTag pushes tag to remote.
 func (r *Repository) PushTag(tag string, remote string) error {
 	return r.PushTags([]string{tag}, remote)


### PR DESCRIPTION
In some development situations, users may want gotagger to report an
incremented version if the worktree is dirty, even if there are no
commits since the latest tag. This adds a new command-line option,
`-dirty`, and a Config member, `DirtyWorktreeIncrement`, that lets
users pick between a minor or patch increment.