### PR TITLE
fix(cli): write error output to stderr

### DIFF
--- a/.stentor.d/61.fix.error-output.md
+++ b/.stentor.d/61.fix.error-output.md
@@ -1,0 +1,3 @@
+`gotagger` error output is now correctly written to stderr.
+
+The error output of the CLI was incorrectly sent to stdin.

--- a/cmd/gotagger/main.go
+++ b/cmd/gotagger/main.go
@@ -149,20 +149,20 @@ func (g *GoTagger) Run() int {
 	}
 	r, err := gotagger.New(path)
 	if err != nil {
-		g.err.Println("error: ", err)
+		g.err.Println("error:", err)
 		return genericErrorExitCode
 	}
 
 	if g.configFile != "" {
 		data, err := os.ReadFile(g.configFile)
 		if err != nil {
-			g.err.Println("error: ", err)
+			g.err.Println("error:", err)
 			return genericErrorExitCode
 		}
 
 		err = r.Config.ParseJSON(data)
 		if err != nil {
-			g.err.Println("error: ", err)
+			g.err.Println("error:", err)
 			return genericErrorExitCode
 		}
 	}
@@ -176,7 +176,7 @@ func (g *GoTagger) Run() int {
 
 	versions, err := r.TagRepo()
 	if err != nil {
-		g.err.Println("error: ", err)
+		g.err.Println("error:", err)
 		return genericErrorExitCode
 	}
 
@@ -255,7 +255,7 @@ func main() {
 		Args:       os.Args[1:],
 		Env:        os.Environ(),
 		Stdout:     os.Stdout,
-		Stderr:     os.Stdin,
+		Stderr:     os.Stderr,
 		WorkingDir: wd,
 	}
 


### PR DESCRIPTION
The cli was incorrectly writing error output to stdin.

Fixes #61