### PR TITLE
feat: add support for filtering commits by path

### DIFF
--- a/.stentor.d/93.feature.path-filtering.md
+++ b/.stentor.d/93.feature.path-filtering.md
@@ -1,0 +1,3 @@
+`gotagger` now takes a `-path` flag
+that restricts version calculation
+to commits that affected files below that directory.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [Pre-Release Incrementing](#pre-release-incrementing)
     - [Version Prefix](#version-prefix)
   - [Go Module Support](#go-module-support)
+  - [Path Filtering](#path-filtering)
 - [Using gotagger as a library](#using-gotagger-as-a-library)
 - [Contributing](#contributing)
 - [License](#license)
@@ -260,6 +261,16 @@ Modules: foo, foo/bar
 `gotagger` will print out all of the versions it tagged
 in the order they are specified in the `Modules` footer.
 
+### Path Filtering
+
+`gotagger` supports versioning individual paths
+within a git repository using a path filter.
+Currently,
+only a single path filter is supported,
+and `gotagger` will return an error
+if a path filter is used in a repository
+that contains go modules
+without setting `-modules=false`.
 
 ## Using gotagger as a library
 

--- a/cmd/gotagger/main_test.go
+++ b/cmd/gotagger/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/sassoftware/gotagger/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,6 +182,62 @@ func TestGoTagger(t *testing.T) {
 			args:      []string{"-force"},
 			wantOut:   "v1.1.0\n",
 			extraTest: assertTag("v1.1.0"),
+		},
+		{
+			title:   "filter to baz subdirectory",
+			args:    []string{"-path", "baz"},
+			wantOut: "v0.1.0\n",
+			extraSetup: func(t *testing.T, repo *git.Repository, path string) {
+				// need to be on the "other" branch
+				w, err := repo.Worktree()
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := w.Checkout(&git.CheckoutOptions{
+					Branch: plumbing.NewBranchReferenceName("other"),
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			title:   "path filter does not exist",
+			args:    []string{"-path", "missing"},
+			wantErr: "error: invalid path filter",
+			wantRc:  1,
+			extraSetup: func(t *testing.T, repo *git.Repository, path string) {
+				// need to be on the "other" branch
+				w, err := repo.Worktree()
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := w.Checkout(&git.CheckoutOptions{
+					Branch: plumbing.NewBranchReferenceName("other"),
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			title:   "path filter is a file",
+			args:    []string{"-path", "foo.go"},
+			wantErr: "error: invalid path filter",
+			wantRc:  1,
+			extraSetup: func(t *testing.T, repo *git.Repository, path string) {
+				// need to be on the "other" branch
+				w, err := repo.Worktree()
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := w.Checkout(&git.CheckoutOptions{
+					Branch: plumbing.NewBranchReferenceName("other"),
+				}); err != nil {
+					t.Fatal(err)
+				}
+			},
 		},
 	}
 

--- a/config.go
+++ b/config.go
@@ -51,8 +51,13 @@ type Config struct {
 	// CommitTypeTable used for looking up version increments based on the commit type.
 	CommitTypeTable mapper.Table
 
-	// Force controlls whether gotagger will create a tag even if HEAD is not a "release" commit.
+	// Force controls whether gotagger will create a tag even if HEAD is not a "release" commit.
 	Force bool
+
+	// Paths is a list of sub-paths within the repo to restrict the git
+	// history used to calculate a version. The versions returned will be
+	// prefixed with their path.
+	Paths []string
 
 	/* TODO
 	// PreRelease is the string that will be used to generate pre-release versions. The
@@ -150,8 +155,8 @@ func (c *Config) ParseJSON(data []byte) error {
 //		v
 func NewDefaultConfig() Config {
 	return Config{
+		CommitTypeTable: mapper.NewTable(nil, mapper.IncrementPatch),
 		RemoteName:      "origin",
 		VersionPrefix:   "v",
-		CommitTypeTable: mapper.NewTable(nil, mapper.IncrementPatch),
 	}
 }


### PR DESCRIPTION
This adds a way limit the commits gotagger considers by path. This lets
projects that include multiple, versioned artifacts to use gotagger to
generate different versions for different parts of their repositories.

Closes #93