### PR TITLE
fix(commit): properly parse scopes with hyphens

### DIFF
--- a/.stentor.d/95.fix.scope-parser.md
+++ b/.stentor.d/95.fix.scope-parser.md
@@ -1,0 +1,5 @@
+`gotagger` properly parses scopes with hyphens.
+
+The regex used by gotagger
+is now essentially the same
+as the default used by conventional-commit-parser.

--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	typeRe   = regexp.MustCompile(`^(?P<type>\w+)(?P<scope>\(\w+\))?(?P<breaking>!)?: (?P<subject>.+)`)
+	typeRe   = regexp.MustCompile(`^(?P<type>\w+)(?:\((?P<scope>[-\w$.*/ ]+)\))?(?P<breaking>!)?: (?P<subject>.+)$`)
 	mergeRe  = regexp.MustCompile(`^Merge "(.*)"$`)
 	revertRe = regexp.MustCompile(`^Revert\s"([\s\S]+)"\s*This reverts commit (\w+)\.`)
 	footerRe = regexp.MustCompile(`^(?P<title>[-\w ]+): (?P<text>.*)`)

--- a/internal/commit/commit_test.go
+++ b/internal/commit/commit_test.go
@@ -48,7 +48,7 @@ func TestCommit_Message(t *testing.T) {
 func TestParse(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		ctype := rapid.StringMatching(`^\w*$`).Draw(t, "type").(string)
-		scope := rapid.StringMatching(`^\w*$`).Draw(t, "scope").(string)
+		scope := rapid.StringMatching(`[\w$.\-*/ ]*`).Draw(t, "scope").(string)
 		isBreaking := rapid.Bool().Draw(t, "breaking").(bool)
 		subject := rapid.StringMatching(`^.*$`).Draw(t, "subject").(string)
 		body := rapid.SliceOf(


### PR DESCRIPTION
This brings gotagger's commit parsing inline with the
conventional-commit-parser library.

Fixes #95