### PR TITLE
ci: fix gotagger make when tagging commit

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Tag commit
         run: |
-          make build/linux/gotagger
+          make build
           build/linux/gotagger -push


### PR DESCRIPTION
make gotagger target should be "make build"