### PR TITLE
ci: use stable and oldstable go versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go_version: [1.18, 1.19]
+        go_version: [stable, oldstable]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - name: Check out code
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
           go-version: ${{ matrix.go_version }}
-          cache: true
 
       - name: Get dependencies
         run: go mod download

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.18
+          go-version: stable
+
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+
       - name: Lint with golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.18
+          go-version: stable
 
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     name: Tag release commit
-    if: "startsWith(github.event.head_commit.message, 'release: ')"
+    if: "${{ startsWith(github.event.head_commit.message, 'release: ') }}"
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.18
+          go-version: stable
           cache: true
 
       - name: Configure git


### PR DESCRIPTION
Requires less churn to keep up with supported versions of Go.